### PR TITLE
Add IP log

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,8 @@ async fn main() {
         loop {
             match listener.accept().await {
                 Ok((mut socket, addr)) => {
-                    println!("client connected");
+                    let ip = addr.ip();
+                    println!("Client connected. IP: {ip}");
                     // Handle as automerge connection
                     tokio::spawn({
                         let repo_clone = repo_clone.clone();
@@ -74,8 +75,8 @@ async fn main() {
                                 .connect_tokio_io(addr, socket, ConnDirection::Incoming)
                                 .await
                             {
-                                Ok(_) => println!("Client connection completed successfully"),
-                                Err(e) => println!("Client connection error: {:?}", e),
+                                Ok(_) => println!("Client connection completed successfully. IP: {ip}"),
+                                Err(e) => println!("Client connection error: {:?}. IP: {ip}", e),
                             }
                         }
                     });


### PR DESCRIPTION
Adds a simple IP log to client connections.

Unfortunately there's no (easy) way I know of to associate modification debug logs from automerge-repo-rs with IPs, so we won't get that level of info with this PR. But it'll at least allow us to know who's connected at any given time.