### PR TITLE
Description endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +283,52 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "concurrent-queue"
@@ -564,6 +660,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +898,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,6 +1065,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "parking"
@@ -1277,11 +1391,12 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "automerge",
  "axum",
  "chrono",
+ "clap",
  "futures",
  "rayon",
  "samod",
@@ -1294,6 +1409,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 
@@ -1387,6 +1503,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "symlink"
@@ -1717,6 +1839,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1724,6 +1847,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "1.0.1"
+version = "2.0.0"
 edition = "2021"
 
 [dependencies]
@@ -20,6 +20,8 @@ chrono = "0.4.45"
 thiserror = "2.0.19"
 serde = { version = "1.0.229", features = ["derive"] }
 tokio-util = "0.7.19"
+clap = { version = "4.6.4", features = ["derive"] }
+url = { version = "2.5.8", features = ["serde"] }
 
 # create profile release_debug
 [profile.release_debug]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,16 +14,17 @@ RUN useradd --uid 10001 --create-home --shell /usr/sbin/nologin backstitch \
 
 COPY --from=builder /app/target/release/server /usr/local/bin/backstitch-sync-server
 
+COPY docker/entrypoint.sh /usr/local/bin/backstitch-entrypoint.sh
+RUN chmod +x /usr/local/bin/backstitch-entrypoint.sh
+
 USER backstitch
 
-ENV DATA_DIR=/data
-ENV PORT=8085
-ENV HTTP_PORT=3000
 ENV RUST_LOG=info,samod=info,samod_core=info
+ENV RUST_BACKTRACE=1
 
 VOLUME ["/data"]
 
 EXPOSE 8085/tcp
 EXPOSE 3000/tcp
 
-ENTRYPOINT ["backstitch-sync-server"]
+ENTRYPOINT ["/usr/local/bin/backstitch-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -8,27 +8,13 @@ Join our [Discord](https://discord.gg/SkW9vem5Ez) for support & community!
 
 An example Docker Compose configuration is available in `compose.example.yml`. It runs the image from the ghcr.io `backstitch-sync-server` package.
 
-```
+```sh
 docker compose -f compose.example.yml up
 ```
 
-Or, to run the published image without Docker Compose:
+See [`compose.example.yml`](./compose.example.yml) for details on configuration.
 
-```
-docker run --rm \
-  -p 8085:8085 \
-  -p 3000:3000 \
-  -v backstitch-data:/data \
-  ghcr.io/inkandswitch/backstitch-sync-server:latest
-```
-
-The container uses these defaults:
-
-| Variable | Default | Description |
-| --- | --- | --- |
-| `DATA_DIR` | `/data` | Directory where sync data is stored. Mount this as a volume for persistence. |
-| `PORT` | `8085` | TCP `samod` sync server port. |
-| `HTTP_PORT` | `3000` | HTTP server port for testing and document inspection. |
+To connect a Backstitch client, enter the url `http://<ADDRESS>:<PORT>`. The port should be the port that maps to the HTTP port (`3000` in the Docker container), NOT the sync port (`8085`). If the mapped HTTP port is `80`, you don't need to specify the port.
 
 ## VPN Tunnel
 
@@ -41,7 +27,7 @@ Alternatively, you can directly port-forward with your server provider or home r
 
 Clone this repository locally. To build and run, first, install [Rust and Cargo](https://rust-lang.org/tools/install/). Then, to install `just`, run:
 
-```
+```sh
 cargo install just
 ```
 
@@ -49,13 +35,22 @@ cargo install just
 
 To build and run the server with defaults, use `just run`:
 
+```sh
+just run
 ```
-just run [data_dir] [port] [http_port] [debug|release]
+
+For a list of potential configurable arguments:
+
+```sh
+just
 ```
+
 
 Data will be stored to `./data` by default, but can be overridden.
 
-The server will run a TCP `samod` connection at `localhost:8085`, as well as an HTTP server for testing at `localhost:3000`. 
+The server will run a TCP `samod` connection at `localhost:8085`, as well as an HTTP server for server-description and testing at `localhost:3000`.
+
+When you wish to connect with a Backstitch client, enter the `http_port` server URL. The default is `http://localhost:3000`.
 
 
 ## IMPORTANT: Security!

--- a/compose.example.yml
+++ b/compose.example.yml
@@ -1,17 +1,17 @@
 services:
   backstitch-sync-server:
-    image: ghcr.io/inkandswitch/backstitch-sync-server:latest
+    image: ghcr.io/inkandswitch/backstitch-sync-server:pr-22
     restart: unless-stopped
     environment:
       # The desired automerge sync port for Backstitch. This MUST be specified.
       # The port should probably match the external port specified in `ports`, unless you're doing something weird.
-      PUBLIC_SYNC_PORT: "8085"
+      PUBLIC_SYNC_PORT: "5000"
       # The authentication scheme to use. This MUST be specified.
       # We currently support no authentication. In a future release, we will support `oidc` for advanced OAuth flows.
       AUTH: "none"
     ports:
-      - "8085:8085" # Change the first part to your desired external sync server port. 
-      - "80:3000" # Change the first part to the desired external HTTP server port. This will be the port entered into the Backstitch client.
+      - "5000:8085" # Change the first part to your desired external sync server port. 
+      - "9000:3000" # Change the first part to the desired external HTTP server port. This will be the port entered into the Backstitch client.
                   # If you don't want to enter a port in the Backstitch client, it defaults to port 80. (TODO: Change this to 443 when we have HTTPS?)
     volumes:
       # For data persistance, mount this backstitch-data volume.

--- a/compose.example.yml
+++ b/compose.example.yml
@@ -3,13 +3,18 @@ services:
     image: ghcr.io/inkandswitch/backstitch-sync-server:latest
     restart: unless-stopped
     environment:
-      DATA_DIR: /data
-      PORT: "8085"
-      HTTP_PORT: "3000"
+      # The desired automerge sync port for Backstitch. This MUST be specified.
+      # The port should probably match the external port specified in `ports`, unless you're doing something weird.
+      PUBLIC_SYNC_PORT: "8085"
+      # The authentication scheme to use. This MUST be specified.
+      # We currently support no authentication. In a future release, we will support `oidc` for advanced OAuth flows.
+      AUTH: "none"
     ports:
-      - "8085:8085"
-      - "3000:3000"
+      - "8085:8085" # Change the first part to your desired external sync server port. 
+      - "80:3000" # Change the first part to the desired external HTTP server port. This will be the port entered into the Backstitch client.
+                  # If you don't want to enter a port in the Backstitch client, it defaults to port 80. (TODO: Change this to 443 when we have HTTPS?)
     volumes:
+      # For data persistance, mount this backstitch-data volume.
       - backstitch-data:/data
 
 volumes:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+set -- \
+    --data-dir "/data" \
+    --sync-port "8085" \
+    --public-sync-port "${PUBLIC_SYNC_PORT:-8085}" \
+    --http-port "3000" \
+    --auth "${AUTH:-none}"
+
+if [ -n "${WEBVIEWER:-}" ]; then
+    set -- "$@" --webviewer "$WEBVIEWER"
+fi
+
+exec backstitch-sync-server "$@"

--- a/justfile
+++ b/justfile
@@ -2,12 +2,22 @@
   just --list
 
 [arg('profile', pattern='debug|release')]
-run data_dir="./data" port="8085" http_port="3000" profile="release":
+[arg('auth', pattern='none')]
+run data_dir="./data" sync_port="8085" http_port="3000" profile="release" auth="none" webviewer="" :
     #!/usr/bin/env sh
-    mkdir {{data_dir}}
-    RUST_BACKTRACE=1 \
+    mkdir -p {{data_dir}}
+
+    webviewer_arg=""
+    if [ -n "{{webviewer}}" ]; then
+        webviewer_arg="--webviewer \"{{webviewer}}\""
+    fi
+
+    RUST_BACKTRACE=full \
     RUST_LOG=automerge_repo=debug,info \
-    DATA_DIR={{data_dir}} \
-    PORT={{port}} \
-    HTTP_PORT={{http_port}} \
-    cargo run --{{profile}}
+    cargo run --{{profile}} -- \
+        --data-dir "{{data_dir}}" \
+        --public-sync-port "{{sync_port}}" \
+        --sync-port "{{sync_port}}" \
+        --http-port "{{http_port}}" \
+        --auth "{{auth}}" \
+        $webviewer_arg

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,35 @@
+use std::path::PathBuf;
+
+use clap::{Parser, ValueEnum};
+use serde::Serialize;
+use url::Url;
+
+#[derive(ValueEnum, Debug, Clone, Serialize)]
+pub enum Authentication {
+    None,
+}
+
+#[derive(Parser, Debug, Clone)]
+#[command(rename_all = "kebab-case")]
+pub struct CommandConfig {
+    #[arg(long)]
+    #[clap(
+        help = "The public sync port to use. This will be given to the Backstitch client during the HTTP handshake."
+    )]
+    pub public_sync_port: Url,
+    #[arg(long)]
+    #[clap(help = "The internal localhost port to use for the sync server.")]
+    pub sync_port: u16,
+    #[arg(long)]
+    #[clap(help = "The internal localhost port to use for the HTTP server.")]
+    pub http_port: u16,
+    #[arg(long)]
+    #[clap(help = "The authentication scheme to use.")]
+    pub auth: Authentication,
+    #[arg(long)]
+    #[clap(help = "The webviewer URL to recommend, if any.")]
+    pub webviewer: Option<Url>,
+    #[arg(long)]
+    #[clap(help = "The data directory to use.")]
+    pub data_dir: PathBuf,
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,7 @@ pub struct CommandConfig {
     #[clap(
         help = "The public sync port to use. This will be given to the Backstitch client during the HTTP handshake."
     )]
-    pub public_sync_port: Url,
+    pub public_sync_port: u16,
     #[arg(long)]
     #[clap(help = "The internal localhost port to use for the sync server.")]
     pub sync_port: u16,

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use url::Url;
 
 #[derive(ValueEnum, Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Authentication {
     None,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,28 +1,32 @@
 use std::sync::Arc;
 
 use axum::{routing::get, Router};
+use clap::Parser;
 use tokio::sync::Semaphore;
 use tower_http::cors::CorsLayer;
 
-use crate::web::WebEndpointState;
+use crate::{config::CommandConfig, web::WebEndpointState};
 
 mod bans;
+mod config;
 mod sync;
 mod tracing;
 mod web;
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
+    let config = CommandConfig::parse();
     tracing::initialize_tracing();
 
     let web_semaphore = Arc::new(Semaphore::new(100));
 
     // ends on drop
-    let sync_server = sync::SyncServer::new().await;
+    let sync_server = sync::SyncServer::new(config.sync_port, &config.data_dir).await;
 
     let state = WebEndpointState {
         repo: sync_server.repo(),
         semaphore: web_semaphore.clone(),
+        config: Arc::new(config.clone()),
     };
 
     // Start the HTTP server
@@ -33,11 +37,11 @@ async fn main() {
         .route("/doc_at/{id}/{change_hash}", get(web::doc_at))
         .route("/list_changes/{id}", get(web::list_changes))
         .route("/", get(|| async { "fetch documents with /doc/{id}" }))
+        .route("/describe", get(web::describe))
         .with_state(state)
         .layer(CorsLayer::permissive());
 
-    let http_port = std::env::var("HTTP_PORT").unwrap_or_else(|_| "80".to_string());
-    let http_addr = format!("0.0.0.0:{}", http_port);
+    let http_addr = format!("0.0.0.0:{}", config.http_port);
     println!("starting HTTP server on {}", http_addr);
 
     let listener = tokio::net::TcpListener::bind(http_addr).await.unwrap();

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,4 +1,4 @@
-use std::{net::IpAddr, sync::Arc};
+use std::{net::IpAddr, path::Path, sync::Arc};
 
 use samod::{
     storage::TokioFilesystemStorage, AcceptorHandle, ConcurrencyConfig, ConnFinishedReason,
@@ -36,10 +36,8 @@ impl Drop for SyncServer {
 }
 
 impl SyncServer {
-    pub async fn new() -> Self {
+    pub async fn new(port: u16, data_dir: &Path) -> Self {
         // get home directory
-        let data_dir =
-            std::env::var("DATA_DIR").expect("environment variable DATA_DIR must be set");
         let storage = TokioFilesystemStorage::new(data_dir);
 
         let repo = Repo::build_tokio()
@@ -60,7 +58,7 @@ impl SyncServer {
             }),
         };
         let inner = this.inner.clone();
-        tokio::spawn(async move { inner.server_loop().await });
+        tokio::spawn(async move { inner.server_loop(port).await });
         this
     }
 
@@ -70,9 +68,8 @@ impl SyncServer {
 }
 
 impl SyncServerInner {
-    async fn server_loop(&self) {
+    async fn server_loop(&self, port: u16) {
         // Start the automerge sync server
-        let port: String = std::env::var("PORT").unwrap_or_else(|_| "8085".to_string());
         let addr = format!("0.0.0.0:{}", port);
         let acceptor = self
             .repo

--- a/src/web.rs
+++ b/src/web.rs
@@ -12,11 +12,15 @@ use samod::{DocHandle, DocumentId, Repo};
 use serde::Serialize;
 use thiserror::Error;
 use tokio::sync::Semaphore;
+use url::Url;
+
+use crate::config::{Authentication, CommandConfig};
 
 #[derive(Clone)]
 pub struct WebEndpointState {
     pub repo: Repo,
     pub semaphore: Arc<Semaphore>,
+    pub config: Arc<CommandConfig>,
 }
 
 #[derive(Debug, Error)]
@@ -116,12 +120,33 @@ fn hydrate_value_to_json(value: &automerge::hydrate::Value) -> serde_json::Value
     }
 }
 
+#[derive(Serialize)]
+pub struct ServerDescription {
+    version: String,
+    webviewer: Option<Url>,
+    sync_port: u16,
+    auth: Authentication,
+}
+
+pub async fn describe(
+    State(state): State<WebEndpointState>,
+) -> Result<Json<ServerDescription>, WebError> {
+    let _permit = state.semaphore.acquire().await.unwrap();
+    tracing::info!("Received request to describe");
+    Ok(Json(ServerDescription {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        auth: state.config.auth.clone(),
+        sync_port: state.config.sync_port.clone(),
+        webviewer: state.config.webviewer.clone(),
+    }))
+}
+
 pub async fn doc(
     Path(id): Path<String>,
     State(state): State<WebEndpointState>,
 ) -> Result<Json<serde_json::Value>, WebError> {
-    tracing::info!("Received request for document ID: {}", id);
     let _permit = state.semaphore.acquire().await.unwrap();
+    tracing::info!("Received request for document ID: {}", id);
     let doc_handle = get_handle(&id, &state).await?;
     let checked_out_doc_json =
         doc_handle.with_document(|d| serde_json::to_value(automerge::AutoSerde::from(&*d)))?;
@@ -133,8 +158,8 @@ pub async fn doc_at(
     Path((id, change_hash)): Path<(String, String)>,
     State(state): State<WebEndpointState>,
 ) -> Result<Json<serde_json::Value>, WebError> {
-    tracing::info!("Received request for document ID: {id} at change hash: {change_hash}");
     let _permit = state.semaphore.acquire().await.unwrap();
+    tracing::info!("Received request for document ID: {id} at change hash: {change_hash}");
     let doc_handle = get_handle(&id, &state).await?;
 
     let change_hashes = parse_change_hashes(&change_hash)?;
@@ -153,8 +178,8 @@ pub async fn last_heads(
     Path(id): Path<String>,
     State(state): State<WebEndpointState>,
 ) -> Result<Json<Vec<ChangeHash>>, WebError> {
-    println!("Received request for last heads of document ID: {}", id);
     let _permit = state.semaphore.acquire().await.unwrap();
+    println!("Received request for last heads of document ID: {}", id);
     let doc_handle = get_handle(&id, &state).await?;
 
     Ok(Json(doc_handle.with_document(|d| d.get_heads())))
@@ -164,8 +189,8 @@ pub async fn list_changes(
     Path(id): Path<String>,
     State(state): State<WebEndpointState>,
 ) -> Result<Json<HashMap<String, Change>>, WebError> {
-    tracing::info!("Received request for changes list of document ID: {id}");
     let _permit = state.semaphore.acquire().await.unwrap();
+    tracing::info!("Received request for changes list of document ID: {id}");
     let doc_handle = get_handle(&id, &state).await?;
 
     Ok(Json(doc_handle.with_document(|d| {

--- a/src/web.rs
+++ b/src/web.rs
@@ -136,7 +136,7 @@ pub async fn describe(
     Ok(Json(ServerDescription {
         version: env!("CARGO_PKG_VERSION").to_string(),
         auth: state.config.auth.clone(),
-        sync_port: state.config.sync_port.clone(),
+        sync_port: state.config.public_sync_port.clone(),
         webviewer: state.config.webviewer.clone(),
     }))
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -136,7 +136,7 @@ pub async fn describe(
     Ok(Json(ServerDescription {
         version: env!("CARGO_PKG_VERSION").to_string(),
         auth: state.config.auth.clone(),
-        sync_port: state.config.public_sync_port.clone(),
+        sync_port: state.config.public_sync_port,
         webviewer: state.config.webviewer.clone(),
     }))
 }


### PR DESCRIPTION
Provides the `/describe` http endpoint.

Before this is released, we must update Backstitch to grab the server's description before connecting. As such, Backstitch servers will no longer be provided as tcp:// URLs, rather, http:// URLs. Automerge sync servers that want to support Backstitch must now provide this endpoint. 